### PR TITLE
fix: config path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
 configs:
   telegraf-config:
-    file: $PWD/conf/telegraf/telegraf.conf
+    file: ./conf/telegraf/telegraf.conf
 
 networks:
   tig-net:


### PR DESCRIPTION
Without this change I would get the following error:

```
open /conf/telegraf/telegraf.conf: no such file or directory
```